### PR TITLE
Fix SQL command to revert to old Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Dockerfile will create a user named `admin` with a default password of `pass
 To make more users, run the `create_user` script from inside the running container.  `docker exec -it {containerid} /bin/bash` The script is in `/cartodb/script/create_user` edit it to set the new username and password, then run it `sh create_user`
 
 ###Revert to old Editor
-We are using this carto server strictly as a tile/data service, so the builder is not needed, but is enabled by default.  To disable it, you must run SQL `update users set builder_enabled = 't' where username = 'myusername';` To run this sql, run a command prompt in the running container `docker exec -it {containerid} /bin/bash` Once you are in, switch to postgres user `su postgres` and use psql to connect `psql -d carto_db_production`
+We are using this carto server strictly as a tile/data service, so the builder is not needed, but is enabled by default.  To disable it, you must run SQL `update users set builder_enabled = false where username = 'myusername';` To run this sql, run a command prompt in the running container `docker exec -it {containerid} /bin/bash` Once you are in, switch to postgres user `su postgres` and use psql to connect `psql -d carto_db_production`
 
 ###To enable GZIP
 This can also be done in nginx, you just need to enable gzip and add the mime types that carto uses.  


### PR DESCRIPTION
Original code, setting builder_enabled = 't' is how you would turn ON builder. If you want to revert to editor, you need to change this value to false.