### PR TITLE
Specify bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ ruby-install ruby 2.2.3
 
 ENV PATH=$PATH:/opt/rubies/ruby-2.2.3/bin 
 
-RUN gem install bundler &&\
+RUN gem install bundler --version=1.17.3 &&\
 gem install compass
 
 ENV RAILS_ENV production


### PR DESCRIPTION
Before, the Dockerfile was installing the latest bundler version, which is only compatible with Ruby >= 2.3.0. I've changed the bundler version to 1.17.3, which requires Ruby >= 1.8.7. Version info here: https://rubygems.org/gems/bundler/versions/1.17.3